### PR TITLE
Update support to PHP 8.3 and Laravel 11.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ on: [push]
 
 jobs:
   syntax:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
@@ -16,10 +16,10 @@ jobs:
         run: composer syntax
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Package to perform health check analysis based on defined checkers.
 
 ## Requirements
 
-- PHP >= 8.1
-- Laravel >= 9.0
+- PHP >= 8.3
+- Laravel >= 10.0
 
 ## Instalation
 

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     }
   ],
   "require": {
-    "php": "^8.1",
-    "illuminate/support": "^9.0|^10.0",
+    "php": "^8.3",
+    "illuminate/support": "^10.0|^11.0",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.1",
+    "phpunit/phpunit": "^11.2",
     "letsgoi/php-code-style": "^1.3",
-    "orchestra/testbench": "^7.2|^8.5"
+    "orchestra/testbench": "^9.1"
   },
   "autoload": {
     "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build: ./docker/php-cli

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli-alpine
+FROM php:8.3-cli-alpine
 
 RUN apk add git
 

--- a/tests/Checkers/AppKeyCheckerTest.php
+++ b/tests/Checkers/AppKeyCheckerTest.php
@@ -5,10 +5,11 @@ namespace Letsgoi\HealthCheck\Tests\Checkers;
 use Illuminate\Support\Facades\Config;
 use Letsgoi\HealthCheck\Checkers\AppKeyChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class AppKeyCheckerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_app_key_is_setted()
     {
         Config::set('app.key', 'ANY_KEY');
@@ -18,7 +19,7 @@ class AppKeyCheckerTest extends TestCase
         $this->assertTrue($appKeyChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_app_key_is_not_setted()
     {
         Config::set('app.key', null);

--- a/tests/Checkers/DatabaseConnectionCheckerTest.php
+++ b/tests/Checkers/DatabaseConnectionCheckerTest.php
@@ -8,10 +8,11 @@ use Illuminate\Support\Facades\DB;
 use Letsgoi\HealthCheck\Checkers\DatabaseConnectionChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class DatabaseConnectionCheckerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_app_is_database_connection_is_ok()
     {
         $connection = $this->mock(ConnectionInterface::class, static function (MockInterface $mock) {
@@ -27,7 +28,7 @@ class DatabaseConnectionCheckerTest extends TestCase
         $this->assertTrue($databaseConnectionChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_app_is_database_connection_is_ko()
     {
         $connection = $this->mock(ConnectionInterface::class, static function (MockInterface $mock) {

--- a/tests/Checkers/DatabaseMigrationsCheckerTest.php
+++ b/tests/Checkers/DatabaseMigrationsCheckerTest.php
@@ -5,10 +5,11 @@ namespace Letsgoi\HealthCheck\Tests\Checkers;
 use Illuminate\Support\Facades\Artisan;
 use Letsgoi\HealthCheck\Checkers\DatabaseMigrationsChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class DatabaseMigrationsCheckerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_migrations_are_up_to_date()
     {
         Artisan::shouldReceive('call')
@@ -24,7 +25,7 @@ class DatabaseMigrationsCheckerTest extends TestCase
         $this->assertTrue($databaseMigrationsChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_migrations_are_not_up_to_date()
     {
         Artisan::shouldReceive('call')

--- a/tests/Checkers/DebugCheckerTest.php
+++ b/tests/Checkers/DebugCheckerTest.php
@@ -5,10 +5,11 @@ namespace Letsgoi\HealthCheck\Tests\Checkers;
 use Illuminate\Support\Facades\Config;
 use Letsgoi\HealthCheck\Checkers\DebugChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class DebugCheckerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_application_is_not_in_debug_mode()
     {
         Config::set('app.debug', false);
@@ -18,7 +19,7 @@ class DebugCheckerTest extends TestCase
         $this->assertTrue($debugChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_application_is_in_debug_mode()
     {
         Config::set('app.debug', true);

--- a/tests/Checkers/EnvFileCheckerTest.php
+++ b/tests/Checkers/EnvFileCheckerTest.php
@@ -4,6 +4,7 @@ namespace Letsgoi\HealthCheck\Tests\Checkers;
 
 use Letsgoi\HealthCheck\Checkers\EnvFileChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class EnvFileCheckerTest extends TestCase
 {
@@ -14,7 +15,7 @@ class EnvFileCheckerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_env_file_exists()
     {
         touch(base_path('.env'));
@@ -24,7 +25,7 @@ class EnvFileCheckerTest extends TestCase
         $this->assertTrue($envFileChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_env_file_not_exists()
     {
         $envFileChecker = new EnvFileChecker();

--- a/tests/Checkers/WritablePathsCheckerTest.php
+++ b/tests/Checkers/WritablePathsCheckerTest.php
@@ -6,13 +6,14 @@ use Illuminate\Filesystem\Filesystem;
 use Letsgoi\HealthCheck\Checkers\WritablePathsChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class WritablePathsCheckerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_if_storage_and_cache_paths_are_writable()
     {
-        $this->mock(Filesystem::class, static function(MockInterface $mock) {
+        $this->mock(Filesystem::class, static function (MockInterface $mock) {
             $mock->shouldReceive('isWritable')
                 ->with(base_path('bootstrap/cache'))
                 ->once()
@@ -29,10 +30,10 @@ class WritablePathsCheckerTest extends TestCase
         $this->assertTrue($writablePathsChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_cache_path_is_not_writable()
     {
-        $this->mock(Filesystem::class, static function(MockInterface $mock) {
+        $this->mock(Filesystem::class, static function (MockInterface $mock) {
             $mock->shouldReceive('isWritable')
                 ->with(base_path('bootstrap/cache'))
                 ->once()
@@ -44,10 +45,10 @@ class WritablePathsCheckerTest extends TestCase
         $this->assertFalse($writablePathsChecker->check());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_false_if_storage_path_is_not_writable()
     {
-        $this->mock(Filesystem::class, static function(MockInterface $mock) {
+        $this->mock(Filesystem::class, static function (MockInterface $mock) {
             $mock->shouldReceive('isWritable')
                 ->with(base_path('bootstrap/cache'))
                 ->once()

--- a/tests/Console/HealthCheckCommandTest.php
+++ b/tests/Console/HealthCheckCommandTest.php
@@ -6,10 +6,11 @@ use Letsgoi\HealthCheck\HealthCheck;
 use Letsgoi\HealthCheck\Tests\Stubs\FakeOkChecker;
 use Letsgoi\HealthCheck\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class HealthCheckCommandTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_health_check_with_all_checkers_on_command()
     {
         $this->mock(HealthCheck::class, static function (MockInterface $mock) {
@@ -22,7 +23,7 @@ class HealthCheckCommandTest extends TestCase
             ->expectsOutput('All checkers are ok.');
     }
 
-    /** @test */
+    #[Test]
     public function it_should_health_check_with_one_checker_on_command()
     {
         $this->mock(HealthCheck::class, static function (MockInterface $mock) {
@@ -32,6 +33,6 @@ class HealthCheckCommandTest extends TestCase
         });
 
         $this->artisan('health-check', ['--checker' => FakeOkChecker::class])
-            ->expectsOutput( FakeOkChecker::class . ' checker it\'s ok.');
+            ->expectsOutput(FakeOkChecker::class . ' checker it\'s ok.');
     }
 }

--- a/tests/HealthCheckTest.php
+++ b/tests/HealthCheckTest.php
@@ -9,10 +9,11 @@ use Letsgoi\HealthCheck\HealthCheck;
 use Letsgoi\HealthCheck\Tests\Stubs\FakeKoChecker;
 use Letsgoi\HealthCheck\Tests\Stubs\FakeOkChecker;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class HealthCheckTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_true_on_check_ok_checker()
     {
         $healthCheck = new HealthCheck();
@@ -25,7 +26,7 @@ class HealthCheckTest extends TestCase
         $this->assertTrue($healthCheck->check($checker));
     }
 
-    /** @test */
+    #[Test]
     public function it_should_throw_exception_on_check_failed_checker()
     {
         $this->expectException(HealthCheckerException::class);
@@ -40,7 +41,7 @@ class HealthCheckTest extends TestCase
         $healthCheck->check($checker);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_check_all_active_checkers_and_return_true_if_all_are_ok()
     {
         Config::set('laravel_health_check.checkers', [
@@ -54,14 +55,14 @@ class HealthCheckTest extends TestCase
         $this->assertTrue($healthCheck->healthCheck());
     }
 
-    /** @test */
+    #[Test]
     public function it_should_throw_exception_if_any_of_checkers_is_failing()
     {
         $this->expectException(HealthCheckerException::class);
         $this->expectExceptionMessage(
             "Health check failed:\n\n" .
-            FakeKoChecker::class . " check failed.\n".
-            FakeKoChecker::class . ' check failed.'
+            FakeKoChecker::class . " check failed.\n" .
+            FakeKoChecker::class . ' check failed.',
         );
 
         Config::set('laravel_health_check.checkers', [
@@ -76,7 +77,7 @@ class HealthCheckTest extends TestCase
         $healthCheck->healthCheck();
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_all_errors_of_failing_checkers()
     {
         Config::set('laravel_health_check.checkers', [
@@ -92,7 +93,7 @@ class HealthCheckTest extends TestCase
                 FakeKoChecker::class . ' check failed.',
                 FakeKoChecker::class . ' check failed.',
             ],
-            $healthCheck->getCheckErrors()
+            $healthCheck->getCheckErrors(),
         );
     }
 }

--- a/tests/Http/Controllers/HealthCheckControllerTest.php
+++ b/tests/Http/Controllers/HealthCheckControllerTest.php
@@ -6,10 +6,11 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
 use Letsgoi\HealthCheck\Facades\HealthCheck;
 use Letsgoi\HealthCheck\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HealthCheckControllerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_return_ok_if_all_check_passed_on_endpoint()
     {
         Config::set('laravel_health_check.endpoint.healthy_message', 'ok');
@@ -22,7 +23,7 @@ class HealthCheckControllerTest extends TestCase
             ->assertSee('ok');
     }
 
-    /** @test */
+    #[Test]
     public function it_should_return_server_error_with_check_errors()
     {
         HealthCheck::shouldReceive('getCheckErrors')
@@ -38,7 +39,7 @@ class HealthCheckControllerTest extends TestCase
                 'errors' => [
                     'Check one error',
                     'Check two error',
-                ]
+                ],
             ]);
     }
 }


### PR DESCRIPTION
This PR:

- Adds support to PHP 8.3.
- Updates Docker image to PHP 8.3.
- Adds support to Laravel 11.
- Removes support to Laravel 9.
- Updates to PHPUnit 11. Changes annotations to attributes, as annotations will be deleted in PHPUnit 12. https://docs.phpunit.de/en/11.2/attributes.html
- Updates GitHub workflow.

Private task: https://www.notion.so/b35fa76049c44813ba03a50ee1e0bfd9